### PR TITLE
json schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ TODO.md
 INTEGRATION.md
 PITCH.md
 *.json
+!schema.json
 __pycache__
 python/dist

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,95 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MESC Config Schema",
+    "description": "MESC Config Schema. See https://github.com/paradigmxyz/mesc/blob/main/SPECIFICATION.md",
+    "type": "object",
+    "properties": {
+      "mesc_version": {
+        "type": "string",
+        "default": "MESC 1.0"
+      },
+      "default_endpoint": {
+        "type": "string"
+      },
+      "network_defaults": {
+        "type": "object",
+        "properties": {
+          "chain_id": {
+            "type": "string"
+          }
+        }
+      },
+      "network_names": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      },
+      "endpoints": {
+        "type": "object",
+        "properties": {
+          "endpoint_name": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "chain_id": {
+                "type": "string"
+              },
+              "endpoint_metadata": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "required": []
+      },
+      "profiles": {
+        "type": "object",
+        "properties": {
+          "profile_name": {
+            "type": "object",
+            "properties": {
+              "default_endpoint": {
+                "type": "string"
+              },
+              "network_defaults": {
+                "type": "object",
+                "properties": {
+                  "chain_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "chain_id"
+                ]
+              }
+            },
+            "required": [
+              "default_endpoint",
+              "network_defaults"
+            ]
+          }
+        },
+        "required": []
+      },
+      "global_metadata": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    "required": [
+      "mesc_version",
+      "default_endpoint",
+      "network_defaults",
+      "network_names",
+      "endpoints",
+      "profiles",
+      "global_metadata"
+    ]
+  }
+  


### PR DESCRIPTION
starting off the work on defining JSON schema for MESC. The schema url can them be imported into MESC config file by any user to provide types and autocomplete.

Example:

```jsonc
{
  "$schema": "https://raw.githubusercontent.com/o-az/mesc/6d5bb39c1cbcea06d3467f5788763bda73d9c2d7/schema.json",
  // ...
}
```