### PR TITLE
docs: fix cargo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These implementations provide a consistent language-agnostic interface while sti
 ## Quickstart
 
 The interactive [`mesc`](./cli) CLI tool makes it easy to create and manage a MESC configuration.
-1. Install: `cargo install mesc`
+1. Install: `cargo install mesc-cli`
 2. Create config interactively: `mesc setup`
 
 To create a MESC config manually:


### PR DESCRIPTION
Small issue with the current Quickstart section in the README where users are instructed to use `cargo install mesc` for installation, leading to an error due to the absence of binaries. This replaces that with `cargo install mesc_cli`.