### PR TITLE
Docs: fix install and git clone commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These implementations provide a consistent language-agnostic interface while sti
 ## Quickstart
 
 The interactive [`mesc`](./cli) CLI tool makes it easy to create and manage a MESC configuration.
-1. Install: `cargo install mesc`
+1. Install: `cargo install mesc_cli`
 2. Create config interactively: `mesc setup`
 
 To create a MESC config manually:

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,7 +35,7 @@ Ensure that your cargo install path is on your cli path
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # install mesc
-git clone https://github.io/paradigmxyz/msec
+git clone https://github.io/paradigmxyz/mesc
 cd mesc
 cargo install --path rust/crates/cli
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,7 +35,7 @@ Ensure that your cargo install path is on your cli path
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # install mesc
-git clone https://github.io/paradigmxyz/mesc
+git clone https://github.com/paradigmxyz/mesc
 cd mesc
 cargo install --path rust/crates/cli
 ```


### PR DESCRIPTION
Fixed cargo install commands in README to `cargo install mesc_cli`
Fixed git clone command in cli/README to `git clone https://github.com/paradigmxyz/mesc`