### PR TITLE
Initial Go spec implementation

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/paradigmxyz/mesc/go
+
+go 1.20

--- a/go/pkg/mesc/endpoint/criteria/config.go
+++ b/go/pkg/mesc/endpoint/criteria/config.go
@@ -1,0 +1,34 @@
+package mesc
+
+import model "github.com/paradigmxyz/mesc/go/pkg/mesc/model"
+
+// EndpointFindCriteriaConfig describes the criteria to be used with FindEndpoints
+type EndpointFindCriteriaConfig struct {
+    chainID      *model.ChainID
+    nameContains *string
+    urlContains  *string
+}
+
+// FindEndpointsCriteria provides a means of customizing the finding criteria for endpoints in FindEndpoints.
+type FindEndpointsCriteria func(*EndpointFindCriteriaConfig)
+
+// HasChainID will find endpoints that contain endpoint metadata for the given chain ID.
+func HasChainID(chainID model.ChainID) FindEndpointsCriteria {
+    return func(e *EndpointFindCriteriaConfig) {
+        e.chainID = &chainID
+    }
+}
+
+// NameContains describes a criteria to find endpoints whose name contains the given substring.
+func NameContains(name string) FindEndpointsCriteria {
+    return func(e *EndpointFindCriteriaConfig) {
+        e.nameContains = &name
+    }
+}
+
+// URLContains describes a criteria to find endpoints whose URLs contain the given substring.
+func URLContains(url string) FindEndpointsCriteria {
+    return func(e *EndpointFindCriteriaConfig) {
+        e.urlContains = &url
+    }
+}

--- a/go/pkg/mesc/endpoint/resolution/config.go
+++ b/go/pkg/mesc/endpoint/resolution/config.go
@@ -1,0 +1,26 @@
+package mesc
+
+import model "github.com/paradigmxyz/mesc/go/pkg/mesc/model"
+
+// EndpointResolutionConfig describes configuration and context to be applied during endpoint resolution.
+type EndpointResolutionConfig struct {
+    profile   *string
+    rpcConfig *model.RPCConfig
+}
+
+// EndpointResolutionOption describes a way of configuring the resolution of an endpoint
+type EndpointResolutionOption func(*EndpointResolutionConfig)
+
+// WithProfile will configure endpoint resolution to resolve with the given profile enabled.
+func WithProfile(profile string) EndpointResolutionOption {
+    return func(cfg *EndpointResolutionConfig) {
+        cfg.profile = &profile
+    }
+}
+
+// WithRPCConfig will configure endpoint resolution to resolve from the given RPCConfig.
+func WithRPCConfig(rpcConfig model.RPCConfig) EndpointResolutionOption {
+    return func(cfg *EndpointResolutionConfig) {
+        cfg.rpcConfig = &rpcConfig
+    }
+}

--- a/go/pkg/mesc/endpoints.go
+++ b/go/pkg/mesc/endpoints.go
@@ -1,0 +1,53 @@
+package mesc
+
+import (
+    "context"
+    "errors"
+
+    model "github.com/paradigmxyz/mesc/go/pkg/mesc/model"
+    criteria "github.com/paradigmxyz/mesc/go/pkg/mesc/endpoint/criteria"
+    resolution "github.com/paradigmxyz/mesc/go/pkg/mesc/endpoint/resolution"
+)
+
+// UnresolvableEndpointError defines when an endpoint cannot be resolved.
+type UnresolvableEndpointError struct{}
+
+func (e *UnresolvableEndpointError) Error() string {
+    return "no endpoint metadata could be resolved"
+}
+
+// GetDefaultEndpoint resolves the endpoint metadata, if available, for the default endpoint.
+// This will return UnresolvableEndpointError if no endpoint metadata can be resolved.
+func GetDefaultEndpoint(ctx context.Context, options ...resolution.EndpointResolutionOption) (model.EndpointMetadata, error) {
+    // TODO: implement
+    return EndpointMetadata{}, errors.New("not yet implemented")
+}
+
+// GetEndpointByNetwork resolves the endpoint metadata, if available, for the given chain ID.
+// This will return UnresolvableEndpointError if no endpoint metadata can be resolved.
+func GetEndpointByNetwork(ctx context.Context, chainID model.ChainID, options ..resolution..EndpointResolutionOption) (model.EndpointMetadata, error) {
+    // TODO: implement
+    return EndpointMetadata{}, errors.New("not yet implemented")
+}
+
+// GetEndpointByName resolves the endpoint metadata, if available, for the network for the given name.
+// This will return UnresolvableEndpointError if no endpoint metadata can be resolved.
+func GetEndpointByName(ctx context.Context, name string, options ...resolution.EndpointResolutionOption) (model.EndpointMetadata, error) {
+    // TODO: implement
+    return EndpointMetadata{}, errors.New("not yet implemented")
+}
+
+// GetEndpointsByQuery resolves the endpoint metadata, if found, for the given query.
+// This will return UnresolvableEndpointError if no endpoint metadata can be resolved.
+func GetEndpointsByQuery(ctx context.Context, query string, options ...resolution.EndpointResolutionOption) (model.EndpointMetadata, error) {
+    // TODO: implement
+    return EndpointMetadata{}, errors.New("not yet implemented")
+}
+
+// FindEndpoints will find all endpoint metadata matching the given criteria.
+// If no criteria is provied, then all endpoints will be returned.
+// If no endpoints are found, then an empty slice of EndpointMetadata will be returned.
+func FindEndpoints(ctx context.Context, findCriteria []criteria.FindEndpointsCriteria, options ...resolution.EndpointResolutionOption) ([]model.EndpointMetadata, error) {
+    // TODO: implement
+    return nil, errors.New("not implemented")
+}

--- a/go/pkg/mesc/endpoints.go
+++ b/go/pkg/mesc/endpoints.go
@@ -1,53 +1,46 @@
 package mesc
 
 import (
-    "context"
-    "errors"
+	"context"
+	"errors"
 
-    model "github.com/paradigmxyz/mesc/go/pkg/mesc/model"
-    criteria "github.com/paradigmxyz/mesc/go/pkg/mesc/endpoint/criteria"
-    resolution "github.com/paradigmxyz/mesc/go/pkg/mesc/endpoint/resolution"
+	criteria "github.com/paradigmxyz/mesc/go/pkg/mesc/endpoint/criteria"
+	resolution "github.com/paradigmxyz/mesc/go/pkg/mesc/endpoint/resolution"
+	model "github.com/paradigmxyz/mesc/go/pkg/mesc/model"
 )
 
-// UnresolvableEndpointError defines when an endpoint cannot be resolved.
-type UnresolvableEndpointError struct{}
-
-func (e *UnresolvableEndpointError) Error() string {
-    return "no endpoint metadata could be resolved"
-}
-
 // GetDefaultEndpoint resolves the endpoint metadata, if available, for the default endpoint.
-// This will return UnresolvableEndpointError if no endpoint metadata can be resolved.
-func GetDefaultEndpoint(ctx context.Context, options ...resolution.EndpointResolutionOption) (model.EndpointMetadata, error) {
-    // TODO: implement
-    return EndpointMetadata{}, errors.New("not yet implemented")
+// This will return nil if no endpoint metadata can be resolved.
+func GetDefaultEndpoint(ctx context.Context, options ...resolution.EndpointResolutionOption) (*model.EndpointMetadata, error) {
+	// TODO: implement
+	return nil, errors.New("not yet implemented")
 }
 
 // GetEndpointByNetwork resolves the endpoint metadata, if available, for the given chain ID.
-// This will return UnresolvableEndpointError if no endpoint metadata can be resolved.
-func GetEndpointByNetwork(ctx context.Context, chainID model.ChainID, options ..resolution..EndpointResolutionOption) (model.EndpointMetadata, error) {
-    // TODO: implement
-    return EndpointMetadata{}, errors.New("not yet implemented")
+// This will return nil if no endpoint metadata can be resolved.
+func GetEndpointByNetwork(ctx context.Context, chainID model.ChainID, options ...resolution.EndpointResolutionOption) (*model.EndpointMetadata, error) {
+	// TODO: implement
+	return nil, errors.New("not yet implemented")
 }
 
 // GetEndpointByName resolves the endpoint metadata, if available, for the network for the given name.
-// This will return UnresolvableEndpointError if no endpoint metadata can be resolved.
-func GetEndpointByName(ctx context.Context, name string, options ...resolution.EndpointResolutionOption) (model.EndpointMetadata, error) {
-    // TODO: implement
-    return EndpointMetadata{}, errors.New("not yet implemented")
+// This will return nil if no endpoint metadata can be resolved.
+func GetEndpointByName(ctx context.Context, name string, options ...resolution.EndpointResolutionOption) (*model.EndpointMetadata, error) {
+	// TODO: implement
+	return nil, errors.New("not yet implemented")
 }
 
 // GetEndpointsByQuery resolves the endpoint metadata, if found, for the given query.
-// This will return UnresolvableEndpointError if no endpoint metadata can be resolved.
-func GetEndpointsByQuery(ctx context.Context, query string, options ...resolution.EndpointResolutionOption) (model.EndpointMetadata, error) {
-    // TODO: implement
-    return EndpointMetadata{}, errors.New("not yet implemented")
+// This will return nil if no endpoint metadata can be resolved.
+func GetEndpointsByQuery(ctx context.Context, query string, options ...resolution.EndpointResolutionOption) (*model.EndpointMetadata, error) {
+	// TODO: implement
+	return nil, errors.New("not yet implemented")
 }
 
 // FindEndpoints will find all endpoint metadata matching the given criteria.
-// If no criteria is provied, then all endpoints will be returned.
+// If no criteria is provided, then all endpoints will be returned.
 // If no endpoints are found, then an empty slice of EndpointMetadata will be returned.
-func FindEndpoints(ctx context.Context, findCriteria []criteria.FindEndpointsCriteria, options ...resolution.EndpointResolutionOption) ([]model.EndpointMetadata, error) {
-    // TODO: implement
-    return nil, errors.New("not implemented")
+func FindEndpoints(ctx context.Context, findCriteria []criteria.FindEndpointsCriteria, options ...resolution.EndpointResolutionOption) ([]*model.EndpointMetadata, error) {
+	// TODO: implement
+	return nil, errors.New("not implemented")
 }

--- a/go/pkg/mesc/endpoints.go
+++ b/go/pkg/mesc/endpoints.go
@@ -9,6 +9,14 @@ import (
 	model "github.com/paradigmxyz/mesc/go/pkg/mesc/model"
 )
 
+// FindEndpoints will find all endpoint metadata matching the given criteria.
+// If no criteria is provided, then all endpoints will be returned.
+// If no endpoints are found, then an empty slice of EndpointMetadata will be returned.
+func FindEndpoints(ctx context.Context, findCriteria []criteria.FindEndpointsCriteria, options ...resolution.EndpointResolutionOption) ([]*model.EndpointMetadata, error) {
+	// TODO: implement
+	return nil, errors.New("not implemented")
+}
+
 // GetDefaultEndpoint resolves the endpoint metadata, if available, for the default endpoint.
 // This will return nil if no endpoint metadata can be resolved.
 func GetDefaultEndpoint(ctx context.Context, options ...resolution.EndpointResolutionOption) (*model.EndpointMetadata, error) {
@@ -37,10 +45,8 @@ func GetEndpointsByQuery(ctx context.Context, query string, options ...resolutio
 	return nil, errors.New("not yet implemented")
 }
 
-// FindEndpoints will find all endpoint metadata matching the given criteria.
-// If no criteria is provided, then all endpoints will be returned.
-// If no endpoints are found, then an empty slice of EndpointMetadata will be returned.
-func FindEndpoints(ctx context.Context, findCriteria []criteria.FindEndpointsCriteria, options ...resolution.EndpointResolutionOption) ([]*model.EndpointMetadata, error) {
+// IsMESCEnabled determines if MESC is enabled.
+func IsMESCEnabled(ctx context.Context) (bool, error) {
 	// TODO: implement
-	return nil, errors.New("not implemented")
+	return false, errors.New("not yet implemented")
 }

--- a/go/pkg/mesc/model/chain_id.go
+++ b/go/pkg/mesc/model/chain_id.go
@@ -1,0 +1,13 @@
+package mesc
+
+import "errors"
+
+// ChainID is the definition of a representation of a chain ID,
+// conforming to the format as described in the MESC specification.
+type ChainID string
+
+// ToInt will parse an integer representation of the chain ID.
+func (c ChainID) ToInt() (int64, error) {
+    // TODO: implement parsing of the chain ID per the MESC specification
+    return 0, errors.New("not implemented")
+}

--- a/go/pkg/mesc/model/endpoint_metadata.go
+++ b/go/pkg/mesc/model/endpoint_metadata.go
@@ -1,0 +1,35 @@
+package mesc
+
+const (
+    rateLimitRequestsPerSecondKey = "rate_limit_rps"
+)
+
+// EndpointMetadata describes metadata for an RPC endpoint.
+type EndpointMetadata struct {
+    Name             string         // Name is the name of the endpoint
+    URL              string         // URL is the location of the endpoint
+    ChainID          *ChainID       // ChainID is the chain ID of the string
+    EndpointMetadata map[string]any // EndpointMetadata is a map of both well-defined endpoint metadata and custom metadata
+}
+
+// GetRateLimitPerSecond gets the rate limit of requests per second that the endpoint will allow.
+func (e EndpointMetadata) GetRateLimitPerSecond() (float64, bool) {
+    if e.EndpointMetadata == nil {
+        return 0.0, false
+    }
+
+    rpsAny, hasRPS := e.EndpointMetadata[rateLimitRequestsPerSecondKey]
+    if !hasRPS {
+        return 0.0, false
+    }
+
+    rpsFloat64, isFloat := rpsAny.(float64)
+    if isFloat {
+        return rpsFloat64, true
+    }
+
+    return 0.0, false
+}
+
+// TODO: implement other convenience methods for the other well-defined parameters here:
+// https://github.com/paradigmxyz/mesc/blob/main/SPECIFICATION.md#metadata

--- a/go/pkg/mesc/model/profile.go
+++ b/go/pkg/mesc/model/profile.go
@@ -1,0 +1,13 @@
+package mesc
+
+// Profile describes a profile to contextualize resolved endpoint metadata
+type Profile struct {
+    Name            string             // Name is the name of the profile
+    DefaultEndpoint *ChainID           // DefaultEndpoint contains the ChainID of the default network under this profile, if available
+    NetworkDefaults map[ChainID]string // NetworkDefaults maps ChainID values identifying networks to the name of the default endpoint of that network
+    ProfileMetadata map[string]any     // ProfileMetadata is a combination of both well-defined and custom-defined metadata for this profile
+    UseMESC         bool               // UseMESC, if false, indicates that MESC resolution should not be used when this profile is enabled
+}
+
+// TODO: implement helper methods resolving profile metadata, per the specification here:
+// https://github.com/paradigmxyz/mesc/blob/main/SPECIFICATION.md#metadata

--- a/go/pkg/mesc/model/rpc_config.go
+++ b/go/pkg/mesc/model/rpc_config.go
@@ -1,0 +1,14 @@
+package mesc
+
+// RPCConfig describes a collection of RPC configurations
+type RPCConfig struct {
+    MESCVersion     string                      // MESCVersion describes the version of the MESC specification to which this adheres
+    DefaultEndpoint string                      // DefaultEndpoint is the name of the default endpoint to be used
+    NetworkDefaults map[ChainID]string          // NetworkDefaults maps chain IDs to the names of the default network for each chain
+    Endpoints       map[string]EndpointMetadata // Endpoints maps endpoint metadata by endpoint name
+    Profiles        map[string]Profile          // Profiles maps profiles by their profile names
+    GlobalMetadata  map[string]any              // GlobalMetadata contains metadata relevant across all profiles
+}
+
+// TODO: implement helper methods resolving global metadata, per the specification here:
+// https://github.com/paradigmxyz/mesc/blob/main/SPECIFICATION.md#metadata


### PR DESCRIPTION
This proposes an implementation of a Go interface that conforms to the specification outlined [here](https://github.com/paradigmxyz/mesc/blob/6e52dfecfaa9ea653db8f7c67941c22771c43e8d/SPECIFICATION.md#reference-implementation).

There are numerous TODOs:

* `endpoints.go` has them since this is intended to be merely a stub to be filled in later by actual functionality
* Numerous files under the `model/` namespace have them to call attention to, if it is acceptable to continue implementing, the need to implement helper methods on these models to assist with the parsing and interpretation of the model data (e.g., resolution of formally-defined parameters from metadata `map[string]any` references)

One thing that I would urge to consider is, actually, spinning this out into its own repo (and to do the same for the existing Python and Rust implementations). This has a couple of benefits:

* The use of GitHub releases to version out the libraries would be easier than trying to maintain lockstep (e.g., do you create a version tag if there's a bug fix in the Go implementation, which creates 'empty' releases of the specification, Rust implementation, and Python implementation?)
* It is common within the Go ecosystem to use source code hosted on a GitHub instance as a dependency. Although this can be made to work with a Go module nested under a `go/` folder in the repository, this dependency resolution works best when the `go.mod` file is hosted at the root of the repository - and that would work best if the Go implementation was hosted in its own repo (to avoid questions of why, for example, there's a `go.mod` file at the root of a repo containing Rust and Python code).