### PR TITLE
Correcting typo in git clone URL for Python

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -16,7 +16,7 @@ It has no external dependencies.
 
 ### From Source
 ```
-git clone https://github/paradigmxyz/mesc
+git clone https://github.com/paradigmxyz/mesc
 cd mesc
 pip install ./
 ```


### PR DESCRIPTION
This corrects a typo in the install from source instructions for Python