### PR TITLE
fix: errors in rust doc

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -16,7 +16,7 @@ The `crates/mesc_cli` crate is a tool for reading, writing, and validating MESC 
 
 Inside a cargo project: `cargo add mesc`
 
-Inside a `Cargo.toml`: `mesc = "1.0"`
+Inside a `Cargo.toml`: `mesc = "0.2.0"`
 
 ## Example Usage
 
@@ -56,12 +56,12 @@ pub struct ChainId(String);
 
 Basic read functions
 ```rust
-use mesc;
-use mesc::MescError;
+use mesc::{MescError, Endpoint};
+use std::collections::HashMap;
 
 type OptionalResult = Result<Option<Endpoint>, MescError>;
 type MultiResult = Result<Vec<Endpoint>, MescError>;
-type MetadataResult = Result<HashMap<String, serde_json::Value>, MescError>
+type MetadataResult = Result<HashMap<String, serde_json::Value>, MescError>;
 
 // check whether mesc is enabled
 let enabled: bool = mesc::is_mesc_enabled();
@@ -70,23 +70,24 @@ let enabled: bool = mesc::is_mesc_enabled();
 let endpoint: OptionalResult = mesc::get_default_endpoint(None);
 
 // get the default endpoint of a network
-let endpoint: OptionalResult = mesc::get_endpoint_by_network(5, None);
+let endpoint: OptionalResult = mesc::get_endpoint_by_network(5 as u8, None);
 
 // get the default network for a particular tool
 let chain_id: OptionalResult = mesc::get_default_endpoint(Some("xyz_tool"));
 
 // get the default endpoint of a network for a particular tool
-let endpoint: OptionalResult = mesc::get_endpoint_by_network(5, Some("xyz_tool"));
+let endpoint: OptionalResult = mesc::get_endpoint_by_network(5 as u8, Some("xyz_tool"));
 
 // get an endpoint by name
 let endpoint: OptionalResult = mesc::get_endpoint_by_name("local_goerli");
 
 // parse a user-provided string into a matching endpoint
 // (first try 1. endpoint name, then 2. chain id, then 3. network name)
+let user_str = "local_goerli";
 let endpoint: OptionalResult = mesc::get_endpoint_by_query(user_str, Some("xyz_tool"));
 
 // find all endpoints matching given criteria
-let query = mesc::MultiEndpointQuery::new().chain_id(5);
+let query = mesc::MultiEndpointQuery::new().chain_id(5 as u8).unwrap();
 let endpoints: MultiResult = mesc::find_endpoints(query);
 
 // get non-endpoint metadata


### PR DESCRIPTION
Code examples for rust seems for version "1.0". The latest version is "0.2.0".
The code exapmle in the rust doc can't be complied. And now it is compilable.