### PR TITLE
Add resolution of RPC configuration with override capability

### DIFF
--- a/go/pkg/mesc/endpoint/io/serialization/json.go
+++ b/go/pkg/mesc/endpoint/io/serialization/json.go
@@ -19,6 +19,21 @@ func DeserializeJSON(reader io.Reader) (*model.RPCConfig, error) {
 	return jsonConfig.toModel(), nil
 }
 
+// DeserializeEndpointMetadataJSON deserializes the given representation of endpoint metadata mapped by endpoint name.
+func DeserializeEndpointMetadataJSON(reader io.Reader) (map[string]model.EndpointMetadata, error) {
+	var endpointJSONMetadata map[string]*jsonEndpoint
+	if decodeErr := json.NewDecoder(reader).Decode(&endpointJSONMetadata); decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode endpoint metadata JSON: %w", decodeErr)
+	}
+
+	endpoints := make(map[string]model.EndpointMetadata, len(endpointJSONMetadata))
+	for endpointName, endpointJSON := range endpointJSONMetadata {
+		endpoints[endpointName] = endpointJSON.toModel()
+	}
+
+	return endpoints, nil
+}
+
 func toOptionalChainID(v *string) *model.ChainID {
 	if v == nil {
 		return nil

--- a/go/pkg/mesc/env.go
+++ b/go/pkg/mesc/env.go
@@ -1,0 +1,96 @@
+package mesc
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/paradigmxyz/mesc/go/pkg/mesc/endpoint/io/serialization"
+	model "github.com/paradigmxyz/mesc/go/pkg/mesc/model"
+)
+
+// ResolveRPCConfig resolves an RPC configuration per the MESC specification rules.
+func ResolveRPCConfig(ctx context.Context) (*model.RPCConfig, error) {
+	rpcConfig, resolvedByMode, err := resolveFromMode()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve RPC configuration by mode: %w", err)
+	} else if resolvedByMode {
+		return rpcConfig, nil
+	}
+
+	byPath, hasByPath, err := readRPCConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read RPC configuration from file: %w", err)
+	} else if hasByPath {
+		return byPath, nil
+	}
+
+	byEnv, hasByEnv, err := readRPCConfigEnv()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read RPC configuration from env: %w", err)
+	} else if hasByEnv {
+		return byEnv, nil
+	}
+
+	return nil, fmt.Errorf("unable to resolve MESC configuration")
+}
+
+func readRPCConfigBytes(jsonBytes []byte) (*model.RPCConfig, error) {
+	rpcConfig, serializationErr := serialization.DeserializeJSON(bytes.NewBuffer(jsonBytes))
+	if serializationErr != nil {
+		return nil, fmt.Errorf("failed to deserialize JSON: %w", serializationErr)
+	}
+
+	return rpcConfig, nil
+}
+
+func readRPCConfigEnv() (*model.RPCConfig, bool, error) {
+	mescJSON := os.Getenv("MESC_ENV")
+	if mescJSON == "" {
+		return nil, false, nil
+	}
+
+	rpcConfig, err := readRPCConfigBytes([]byte(mescJSON))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal RPC config JSON from env var: %w", err)
+	}
+
+	return rpcConfig, true, nil
+}
+
+func readRPCConfigFile() (*model.RPCConfig, bool, error) {
+	filePath := os.Getenv("MESC_PATH")
+	if filePath == "" {
+		return nil, false, nil
+	}
+
+	jsonBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read RPC configuration from file '%s': %w", filePath, err)
+	}
+
+	rpcConfig, err := readRPCConfigBytes(jsonBytes)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal RPC config JSON from file '%s': %w", filePath, err)
+	}
+
+	return rpcConfig, true, nil
+}
+
+func resolveFromMode() (*model.RPCConfig, bool, error) {
+	mescMode := os.Getenv("MESC_MODE")
+	switch strings.TrimSpace(mescMode) {
+	case "PATH":
+		return readRPCConfigFile()
+	case "ENV":
+		return readRPCConfigEnv()
+	default:
+		if mescMode != "" {
+			return nil, false, fmt.Errorf("invalid MESC_MODE value: '%s'", mescMode)
+		}
+	}
+
+	return nil, false, nil
+}

--- a/go/pkg/mesc/env.go
+++ b/go/pkg/mesc/env.go
@@ -43,12 +43,7 @@ func applyOverrides(rpcConfig *model.RPCConfig) (*model.RPCConfig, error) {
 	}
 
 	if networkDefaultsOverride := os.Getenv("MESC_NETWORK_DEFAULTS"); networkDefaultsOverride != "" {
-		networkDefaults := rpcConfig.NetworkDefaults
-		if networkDefaults == nil {
-			networkDefaults = make(map[model.ChainID]string)
-			rpcConfig.NetworkDefaults = networkDefaults
-		}
-
+		networkDefaults := make(map[model.ChainID]string)
 		for _, networkDefault := range strings.Split(networkDefaultsOverride, " ") {
 			splitNetworkDefault := strings.Split(networkDefault, "=")
 			if len(splitNetworkDefault) != 2 {
@@ -57,6 +52,20 @@ func applyOverrides(rpcConfig *model.RPCConfig) (*model.RPCConfig, error) {
 
 			networkDefaults[model.ChainID(splitNetworkDefault[0])] = splitNetworkDefault[1]
 		}
+		rpcConfig.NetworkDefaults = networkDefaults
+	}
+
+	if networkNameOverride := os.Getenv("MESC_NETWORK_NAMES"); networkNameOverride != "" {
+		networkNames := make(map[string]model.ChainID)
+		for _, networkName := range strings.Split(networkNameOverride, " ") {
+			splitNetworkName := strings.Split(networkName, "=")
+			if len(splitNetworkName) != 2 {
+				return nil, fmt.Errorf("invalid network name overide: '%s'", networkName)
+			}
+
+			networkNames[splitNetworkName[0]] = model.ChainID(splitNetworkName[1])
+		}
+		rpcConfig.NetworkNames = networkNames
 	}
 
 	return rpcConfig, nil

--- a/go/pkg/mesc/env.go
+++ b/go/pkg/mesc/env.go
@@ -68,6 +68,33 @@ func applyOverrides(rpcConfig *model.RPCConfig) (*model.RPCConfig, error) {
 		rpcConfig.NetworkNames = networkNames
 	}
 
+	if endpointOverrides := os.Getenv("MESC_ENDPOINTS"); endpointOverrides != "" {
+		endpoints := make(map[string]model.EndpointMetadata)
+		for _, endpoint := range strings.Split(endpointOverrides, " ") {
+			splitEndpoint := strings.Split(endpoint, "=")
+			if len(splitEndpoint) != 2 {
+				return nil, fmt.Errorf("invalid endpoint override: '%s'", endpoint)
+			}
+
+			endpoint := model.EndpointMetadata{}
+			endpointKey := splitEndpoint[0]
+			if strings.Contains(endpointKey, ":") {
+				splitKey := strings.Split(endpointKey, ":")
+				endpoint.Name = splitKey[0]
+				endpointKey = splitKey[0]
+				chainID := model.ChainID(splitKey[1])
+				endpoint.ChainID = &chainID
+			} else {
+				endpoint.Name = splitEndpoint[0]
+			}
+
+			endpoint.URL = splitEndpoint[1]
+
+			endpoints[endpointKey] = endpoint
+		}
+		rpcConfig.Endpoints = endpoints
+	}
+
 	return rpcConfig, nil
 }
 

--- a/go/pkg/mesc/env_test.go
+++ b/go/pkg/mesc/env_test.go
@@ -85,6 +85,22 @@ var _ = Describe("Env", func() {
 				), "the network default override should have been applied")
 			})
 		})
+
+		When("there are network names set", func() {
+			BeforeEach(func() {
+				Expect(setAndResetEnv("MESC_NETWORK_NAMES", "zora=7777777 scroll=534352")).To(Succeed(), "setting the network names override should work")
+			})
+
+			It("applies the network names override", func() {
+				rpcConfig, err := mesc.ResolveRPCConfig(ctx)
+				Expect(err).ToNot(HaveOccurred(), "resolving the RPC configurations should not fail")
+				Expect(rpcConfig.NetworkNames).To(And(
+					HaveLen(2),
+					HaveKeyWithValue("zora", model.ChainID("7777777")),
+					HaveKeyWithValue("scroll", model.ChainID("534352")),
+				), "the network names override should be applied")
+			})
+		})
 	})
 
 	When("there is no resolvable RPC configuration", func() {

--- a/go/pkg/mesc/env_test.go
+++ b/go/pkg/mesc/env_test.go
@@ -173,6 +173,22 @@ var _ = Describe("Env", func() {
 				), "the global metadata should be overridden")
 			})
 		})
+
+		When("there is an endpoint metadata override", func() {
+			BeforeEach(func() {
+				Expect(setAndResetEnv("MESC_ENDPOINT_METADATA", `{ "local_ethereum": { "url": "http://localhost:8545" } }`))
+			})
+
+			It("overrides it with the set JSON", func() {
+				rpcConfig, err := mesc.ResolveRPCConfig(ctx)
+				Expect(err).ToNot(HaveOccurred(), "resolving the RPC configurations should not fail")
+				Expect(rpcConfig.Endpoints).To(And(
+					HaveLen(1),
+					HaveKey("local_ethereum"),
+				), "the RPC configuration should have the endpoint metadata loaded")
+				Expect(rpcConfig.Endpoints["local_ethereum"].URL).To(Equal("http://localhost:8545"), "the data for the endpoint should have been deserialized")
+			})
+		})
 	})
 
 	When("there is no resolvable RPC configuration", func() {

--- a/go/pkg/mesc/env_test.go
+++ b/go/pkg/mesc/env_test.go
@@ -157,6 +157,22 @@ var _ = Describe("Env", func() {
 				Expect(profile.UseMESC).To(BeTrue(), "the profile should have MESC enabled")
 			})
 		})
+
+		When("there is a global metadata override", func() {
+			BeforeEach(func() {
+				Expect(setAndResetEnv("MESC_GLOBAL_METADATA", `{ "bool_field": true, "string_field": "str_value" }`))
+			})
+
+			It("assigns the configured metadata as global metadata", func() {
+				rpcConfig, err := mesc.ResolveRPCConfig(ctx)
+				Expect(err).ToNot(HaveOccurred(), "resolving the RPC configurations should not fail")
+				Expect(rpcConfig.GlobalMetadata).To(And(
+					HaveLen(2),
+					HaveKeyWithValue("bool_field", true),
+					HaveKeyWithValue("string_field", "str_value"),
+				), "the global metadata should be overridden")
+			})
+		})
 	})
 
 	When("there is no resolvable RPC configuration", func() {

--- a/go/pkg/mesc/env_test.go
+++ b/go/pkg/mesc/env_test.go
@@ -1,0 +1,60 @@
+package mesc_test
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/paradigmxyz/mesc/go/pkg/mesc"
+)
+
+var _ = Describe("Env", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Context("reading from environmental variables", func() {
+		When("the mode is set to ENV", func() {
+			BeforeEach(func() {
+				Expect(setAndResetEnv("MESC_MODE", "ENV")).To(Succeed(), "setting the mode should succeed")
+			})
+
+			It("reads the configuration from the environment", func() {
+				Expect(setAndResetEnv("MESC_ENV", `{ "mesc_version": "MESC 1.0", "default_endpoint": "ethereum_env" }`))
+
+				rpcConfig, err := mesc.ResolveRPCConfig(ctx)
+				Expect(err).ToNot(HaveOccurred(), "resolving the RPC configuration should not fail")
+				Expect(rpcConfig).ToNot(BeNil(), "the resolved RPC configuration should not be nil")
+				Expect(rpcConfig.DefaultEndpoint).ToNot(BeNil(), "the RPC configuration should have a default endpoint set")
+				Expect(*rpcConfig.DefaultEndpoint).To(Equal("ethereum_env"), "the RPC config should be read from the environmental variable")
+			})
+		})
+
+		When("there is no mode set", func() {
+			When("there is JSON in MESC_ENV", func() {
+				BeforeEach(func() {
+					Expect(setAndResetEnv("MESC_ENV", `{ "mesc_version": "MESC 1.0", "default_endpoint": "ethereum_env_nomode" }`))
+				})
+
+				It("resolves the JSON from the environmental variable", func() {
+					rpcConfig, err := mesc.ResolveRPCConfig(ctx)
+					Expect(err).ToNot(HaveOccurred(), "resolving the RPC configuration should not fail")
+					Expect(rpcConfig).ToNot(BeNil(), "the resolved RPC configuration should not be nil")
+					Expect(rpcConfig.DefaultEndpoint).ToNot(BeNil(), "the RPC configuration should have a default endpoint set")
+					Expect(*rpcConfig.DefaultEndpoint).To(Equal("ethereum_env_nomode"), "the RPC config should be read from the environmental variable")
+				})
+			})
+		})
+	})
+})
+
+func setAndResetEnv(name string, value string) error {
+	originalValue := os.Getenv(name)
+	DeferCleanup(func() {
+		_ = os.Setenv(name, originalValue)
+	})
+	return os.Setenv(name, value)
+}

--- a/go/pkg/mesc/env_test.go
+++ b/go/pkg/mesc/env_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/paradigmxyz/mesc/go/pkg/mesc"
+	"github.com/paradigmxyz/mesc/go/pkg/mesc/model"
 )
 
 var _ = Describe("Env", func() {
@@ -47,6 +48,50 @@ var _ = Describe("Env", func() {
 					Expect(*rpcConfig.DefaultEndpoint).To(Equal("ethereum_env_nomode"), "the RPC config should be read from the environmental variable")
 				})
 			})
+		})
+	})
+
+	Context("applying overrides", func() {
+		BeforeEach(func() {
+			Expect(setAndResetEnv("MESC_MODE", "ENV")).To(Succeed(), "setting the mode should not fail")
+			Expect(setAndResetEnv("MESC_ENV", `{ "mesc_version": "MESC 1.0" }`)).To(Succeed(), "setting the JSON env should not fail")
+		})
+
+		When("there is a default endpoint override", func() {
+			BeforeEach(func() {
+				Expect(setAndResetEnv("MESC_DEFAULT_ENDPOINT", "localhost.default:9999")).To(Succeed(), "setting the default endpoint override should succeed")
+			})
+
+			It("overrides the default endpoint", func() {
+				rpcConfig, err := mesc.ResolveRPCConfig(ctx)
+				Expect(err).ToNot(HaveOccurred(), "resolving the RPC configuration should not fail")
+				Expect(rpcConfig.DefaultEndpoint).ToNot(BeNil(), "the default endpoint should be set")
+				Expect(*rpcConfig.DefaultEndpoint).To(Equal("localhost.default:9999"), "the default endpoint override should be applied")
+			})
+		})
+
+		When("there are network defaults set", func() {
+			BeforeEach(func() {
+				Expect(setAndResetEnv("MESC_NETWORK_DEFAULTS", "5=alchemy_optimism 1=local_mainnet")).To(Succeed(), "setting the network defaults override should succeed")
+			})
+
+			It("applies the network default overrides", func() {
+				rpcConfig, err := mesc.ResolveRPCConfig(ctx)
+				Expect(err).ToNot(HaveOccurred(), "resolving the RPC configurations should not fail")
+				Expect(rpcConfig.NetworkDefaults).To(And(
+					HaveLen(2),
+					HaveKeyWithValue(model.ChainID("1"), "local_mainnet"),
+					HaveKeyWithValue(model.ChainID("5"), "alchemy_optimism"),
+				), "the network default override should have been applied")
+			})
+		})
+	})
+
+	When("there is no resolvable RPC configuration", func() {
+		It("fails to resolve an RPC configuration", func() {
+			_, err := mesc.ResolveRPCConfig(ctx)
+			Expect(err).To(HaveOccurred(), "resolving the RPC configuration should fail")
+			Expect(err.Error()).To(Equal("unable to resolve MESC configuration"), "it should fail for the correct reason")
 		})
 	})
 })

--- a/go/pkg/mesc/mesc_suite_test.go
+++ b/go/pkg/mesc/mesc_suite_test.go
@@ -1,0 +1,13 @@
+package mesc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMesc(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mesc Suite")
+}


### PR DESCRIPTION
This adds the ability to resolve the RPC configuration per what the specification outlines [here](https://github.com/paradigmxyz/mesc/blob/52205f77923b4148465fadf8f4c5bca98c0d5b5b/SPECIFICATION.md#environment-setup), with support for overrides as described [here](https://github.com/paradigmxyz/mesc/blob/52205f77923b4148465fadf8f4c5bca98c0d5b5b/SPECIFICATION.md#environment-overrides).