### PR TITLE
fix(setup): trim endpoint url input

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "mesc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "mesc_cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bat",
  "clap",

--- a/rust/crates/mesc_cli/src/cli/subcommands/setup/endpoints.rs
+++ b/rust/crates/mesc_cli/src/cli/subcommands/setup/endpoints.rs
@@ -8,7 +8,7 @@ use super::{metadata::*, selectors::*};
 
 pub(crate) async fn add_endpoint(config: &mut RpcConfig) -> Result<(), MescCliError> {
     let url = match inquire::Text::new("New endpoint URL?").prompt() {
-        Ok(input) => input,
+        Ok(input) => input.trim().to_string(),
         Err(InquireError::OperationCanceled) => return Ok(()),
         Err(_) => return Err(MescCliError::InvalidInput("invalid input".to_string())),
     };


### PR DESCRIPTION
## Motivation

I was adding a new endpoint and accidentally copied it w/ a leading space: ` https://...`

This broke the transport detection, so it tried to add `https:// https://...` as the endpoint

## Solution

One liner, just trim leading & trailing whitespace from input :)
